### PR TITLE
ScanFile should implement serializable

### DIFF
--- a/src/main/java/me/automationdomination/plugins/threadfix/ScanFile.java
+++ b/src/main/java/me/automationdomination/plugins/threadfix/ScanFile.java
@@ -1,17 +1,18 @@
 package me.automationdomination.plugins.threadfix;
 
+import java.io.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
 /**
  * An artifact that can be uploaded to a ThreadFix server for an
  * application
  */
-public final class ScanFile extends AbstractDescribableImpl<ScanFile> {
+public final class ScanFile extends AbstractDescribableImpl<ScanFile> implements Serializable {
 
     private final String path;
 
@@ -57,7 +58,5 @@ public final class ScanFile extends AbstractDescribableImpl<ScanFile> {
                 return FormValidation.ok();
             }
         }
-
     }
-
 }


### PR DESCRIPTION
ScanFile should implement serializable because:
- ThreadFixPublisher is serializable but not that much if ScanFile is not, as it's a member of this class
- me.automationdomination.plugins.threadfix.ThreadFixPublisher#uploadScanFile will do a hudson.remoting.Channel#call. I think that a hudson.remoting.UserRequest#UserRequest will be created, that does a serialization, so it won't work.
